### PR TITLE
Rename gland to gris in grids

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -7,8 +7,8 @@ required = True
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/ESMCI/cime.git
-tag = cime5.8.41
+repo_url = https://github.com/billsacks/cime.git
+hash = 4e20c934624f9a4e398e75ca11bc64ce99a40493
 required = True
 
 [cmeps]

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -7,8 +7,8 @@ required = True
 [cime]
 local_path = cime
 protocol = git
-repo_url = https://github.com/billsacks/cime.git
-hash = 4e20c934624f9a4e398e75ca11bc64ce99a40493
+repo_url = https://github.com/ESMCI/cime.git
+tag = branch_tags/cime5.8.41_a01
 required = True
 
 [cmeps]

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -49,11 +49,6 @@ _CISM_CONFIG_GROUPS = ["grid", "glad_climate", "options", "sigma", "time", "para
 _ICESHEET_OPTIONS = OrderedDict([('ais', 'ANTARCTICA'),
                                  ('gris', 'GREENLAND')])
 
-# dictionary mapping ice sheet names to grid specifications
-# if an ice sheet isn't given here, we assume its grid specification is the same as the
-# ice sheet name
-_ICESHEET_GRIDNAMES = {'gris': 'gland'}
-
 # value of 'sigma' that signifies that values are read from a sigma section
 _SIGMA_IN_CONFIG_FILE = 2
 
@@ -222,10 +217,9 @@ def _icesheet_consistency_checks(case, icesheet_names):
     # ------------------------------------------------------------------------
     glc_grid = case.get_value("GLC_GRID")
     for icesheet in _ICESHEET_OPTIONS:
-        # if the given icesheet has a grid name explicitly specified in
-        # _ICESHEET_GRIDNAMES, use that; otherwise, assume that the grid name matches the
-        # icesheet name
-        gridname = _ICESHEET_GRIDNAMES.get(icesheet, icesheet)
+        # assume that the grid name matches the icesheet name (this is true for ais and
+        # gris; if needed, we could add flexibility later)
+        gridname = icesheet
         if icesheet in icesheet_names:
             expect(gridname in glc_grid, "{} included in compset but {} not in grid {}".format(
                 icesheet, gridname, glc_grid))

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -39,7 +39,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="g%gland4">
+  <grid name="g%gris4">
     <mach name="any">
       <pes pesize="any" compset="CISM2">
 	<comment>none</comment>
@@ -76,7 +76,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="g%gland20">
+  <grid name="g%gris20">
     <mach name="any">
       <pes pesize="any" compset="CISM2">
 	<comment>none</comment>

--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -496,9 +496,9 @@ Sub-elements of each entry include:
     <group>derived</group>
     <values>
       <!-- the following is just for the sake of software testing, and should not be used for science -->
-      <value icesheet="gris" glc_grid="gland20">glc/cism/Greenland/gland20.input_c150415.nc</value>
+      <value icesheet="gris" glc_grid="gris20">glc/cism/Greenland/gland20.input_c150415.nc</value>
       <!-- this is the resolution that should be used for science applications with cism2 -->
-      <value icesheet="gris" glc_grid="gland4">glc/cism/Greenland/greenland_4km_epsg3413_c171126.nc</value>
+      <value icesheet="gris" glc_grid="gris4">glc/cism/Greenland/greenland_4km_epsg3413_c171126.nc</value>
     </values>
     <desc>
       Input file
@@ -518,8 +518,8 @@ Sub-elements of each entry include:
     <category>cism_config_grid</category>
     <group>grid</group>
     <values>
-      <value icesheet="gris" glc_grid="gland20" >76</value>
-      <value icesheet="gris" glc_grid="gland4"  >416</value>
+      <value icesheet="gris" glc_grid="gris20" >76</value>
+      <value icesheet="gris" glc_grid="gris4"  >416</value>
     </values>
     <desc>
       Number of nodes in x-direction
@@ -532,8 +532,8 @@ Sub-elements of each entry include:
     <category>cism_config_grid</category>
     <group>grid</group>
     <values>
-      <value icesheet="gris" glc_grid="gland20" >141</value>
-      <value icesheet="gris" glc_grid="gland4"  >704</value>
+      <value icesheet="gris" glc_grid="gris20" >141</value>
+      <value icesheet="gris" glc_grid="gris4"  >704</value>
     </values>
     <desc>
       Number of nodes in y-direction
@@ -559,8 +559,8 @@ Sub-elements of each entry include:
     <category>cism_config_grid</category>
     <group>grid</group>
     <values>
-      <value icesheet="gris" glc_grid="gland20" >20000.</value>
-      <value icesheet="gris" glc_grid="gland4"  >4000.</value>
+      <value icesheet="gris" glc_grid="gris20" >20000.</value>
+      <value icesheet="gris" glc_grid="gris4"  >4000.</value>
     </values>
     <desc>
       Node spacing in x-direction (m)
@@ -573,8 +573,8 @@ Sub-elements of each entry include:
     <category>cism_config_grid</category>
     <group>grid</group>
     <values>
-      <value icesheet="gris" glc_grid="gland20" >20000.</value>
-      <value icesheet="gris" glc_grid="gland4"  >4000.</value>
+      <value icesheet="gris" glc_grid="gris20" >20000.</value>
+      <value icesheet="gris" glc_grid="gris4"  >4000.</value>
     </values>
     <desc>
       Node spacing in y-direction (m)
@@ -1035,11 +1035,11 @@ Sub-elements of each entry include:
     <group>time</group>
     <values>
       <!-- Note: if change dt, also should change dt_diag -->
-      <!-- A dt of 1 seems sufficient for cism2 gland20. However, use 0.5 because (a)
+      <!-- A dt of 1 seems sufficient for cism2 gris20. However, use 0.5 because (a)
            this is less likely to break due to instabilities, and (b) it exercises the
            code in a more typical configuration (i.e., with a sub-annual time step) -->
-      <value icesheet="gris" glc_grid="gland20">0.5</value>
-      <value icesheet="gris" glc_grid="gland4" >0.1</value>
+      <value icesheet="gris" glc_grid="gris20">0.5</value>
+      <value icesheet="gris" glc_grid="gris4" >0.1</value>
     </values>
     <desc>
       Ice sheet timestep (years)
@@ -1093,8 +1093,8 @@ Sub-elements of each entry include:
     <group>time</group>
     <values>
       <!-- Set dt_diag same as dt in order to get diagnostics every time step -->
-      <value icesheet="gris" glc_grid="gland20">0.5</value>
-      <value icesheet="gris" glc_grid="gland4" >0.1</value>
+      <value icesheet="gris" glc_grid="gris20">0.5</value>
+      <value icesheet="gris" glc_grid="gris4" >0.1</value>
     </values>
     <desc>
       Diagnostic frequency (years)
@@ -1112,8 +1112,8 @@ Sub-elements of each entry include:
            instability (in trunk of Jakobshavn); 20-km and 4-km points
            chosen to be roughly the same point in space -->
       <!-- Update 5-2-17: The 4-km point should be updated for the new grid -->
-      <value icesheet="gris" glc_grid="gland20" >19</value>
-      <value icesheet="gris" glc_grid="gland4"  >134</value>
+      <value icesheet="gris" glc_grid="gris20" >19</value>
+      <value icesheet="gris" glc_grid="gris4"  >134</value>
     </values>
     <desc>
       x coordinate of point for diagnostic output
@@ -1127,8 +1127,8 @@ Sub-elements of each entry include:
     <group>time</group>
     <values>
       <!-- See comments for idiag, above -->
-      <value icesheet="gris" glc_grid="gland20" >57</value>
-      <value icesheet="gris" glc_grid="gland4"  >280</value>
+      <value icesheet="gris" glc_grid="gris20" >57</value>
+      <value icesheet="gris" glc_grid="gris4"  >280</value>
     </values>
     <desc>
       y coordinate of point for diagnostic output

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test name="ERI_Ly44" grid="f09_g17_gl20" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Ly44" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -13,7 +13,7 @@
 
     </machines>
   </test>
-  <test name="ERI_Vnuopc_Ly44" grid="f09_g17_gl20" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Vnuopc_Ly44" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -26,7 +26,7 @@
     </machines>
   </test>
 
-  <test name="ERI_Ly15" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Ly15" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="prebeta">
@@ -44,7 +44,7 @@
 
     </machines>
   </test>
-  <test name="ERI_Vnuopc_Ly15" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Vnuopc_Ly15" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="prebeta">
@@ -88,7 +88,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly11" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="ERS_Ly11" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -99,7 +99,7 @@
 
     </machines>
   </test>
-  <test name="ERS_Vnuopc_Ly11" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="ERS_Vnuopc_Ly11" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -111,19 +111,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly11" grid="f09_g17_gl20" compset="T1850Gg" testmods="cism/oneway">
-    <machines>
-
-      <machine name="cheyenne" compiler="gnu" category="aux_glc">
-        <options>
-          <option name="wallclock">0:20</option>
-          <option name="comment">(3-3-16) identical to an existing non-oneway test, which generates some non-zero runoff fluxes</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-  <test name="ERS_Vnuopc_Ly11" grid="f09_g17_gl20" compset="T1850Gg" testmods="cism/oneway">
+  <test name="ERS_Ly11" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/oneway">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -135,8 +123,20 @@
 
     </machines>
   </test>
+  <test name="ERS_Vnuopc_Ly11" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/oneway">
+    <machines>
 
-  <test name="ERS_D_Ly3" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/noevolve">
+      <machine name="cheyenne" compiler="gnu" category="aux_glc">
+        <options>
+          <option name="wallclock">0:20</option>
+          <option name="comment">(3-3-16) identical to an existing non-oneway test, which generates some non-zero runoff fluxes</option>
+        </options>
+      </machine>
+
+    </machines>
+  </test>
+
+  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -149,7 +149,7 @@
     </machines>
   </test>
 
-  <test name="ERI_N2_Ly9" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="ERI_N2_Ly9" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -161,7 +161,7 @@
 
     </machines>
   </test>
-  <test name="ERI_Vnuopc_N2_Ly9" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="ERI_Vnuopc_N2_Ly9" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -174,7 +174,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly3_N2_D" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="ERS_Ly3_N2_D" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -192,7 +192,7 @@
 
     </machines>
   </test>
-  <test name="ERS_Vnuopc_Ly3_N2_D" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="ERS_Vnuopc_Ly3_N2_D" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -211,7 +211,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly7" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="ERS_Ly7" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -229,7 +229,7 @@
 
     </machines>
   </test>
-  <test name="ERS_Vnuopc_Ly7" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="ERS_Vnuopc_Ly7" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -248,7 +248,7 @@
     </machines>
   </test>
 
-  <test name="ERS_D_Ly3" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
+  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -260,7 +260,7 @@
 
     </machines>
   </test>
-  <test name="ERS_Vnuopc_D_Ly3" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
+  <test name="ERS_Vnuopc_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -400,7 +400,7 @@
     </machines>
   </test>
 
-  <test name="NCK_Ly3" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="NCK_Ly3" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="izumi" compiler="pgi" category="prebeta">
@@ -417,7 +417,7 @@
 
     </machines>
   </test>
-  <test name="MCC_Vnuopc_Ly3" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="MCC_Vnuopc_Ly3" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <!-- (2020-11-26) Changing the izumi version to cheyenne for now,
@@ -444,7 +444,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D" grid="T31_g37_gl20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
+  <test name="SMS_D" grid="T31_g37_gris20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -456,7 +456,7 @@
 
     </machines>
   </test>
-  <test name="SMS_Vnuopc_D" grid="T31_g37_gl20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
+  <test name="SMS_Vnuopc_D" grid="T31_g37_gris20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -469,7 +469,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ld5_P24x1" grid="T31_g37_gl20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
+  <test name="SMS_D_Ld5_P24x1" grid="T31_g37_gris20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
 
       <machine name="izumi" compiler="nag" category="aux_glc">
@@ -493,7 +493,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -505,7 +505,7 @@
 
     </machines>
   </test>
-  <test name="SMS_Vnuopc_D_Ly1" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="SMS_Vnuopc_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -518,7 +518,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -529,7 +529,7 @@
 
     </machines>
   </test>
-  <test name="SMS_Vnuopc_D_Ly1" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="SMS_Vnuopc_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -541,7 +541,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -558,7 +558,7 @@
 
     </machines>
   </test>
-  <test name="SMS_Vnuopc_D_Ly1" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="SMS_Vnuopc_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_glc">
@@ -576,7 +576,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1_P24x1" grid="f09_g17_gl4" compset="T1850Gg">
+  <test name="SMS_D_Ly1_P24x1" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
 
       <machine name="izumi" compiler="nag" category="aux_glc">
@@ -596,7 +596,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly3_P24x1" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="SMS_D_Ly3_P24x1" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="izumi" compiler="nag" category="aux_glc">
@@ -609,7 +609,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly5" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERS_Ly5" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -621,7 +621,7 @@
 
     </machines>
   </test>
-  <test name="ERS_Vnuopc_Ly5" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERS_Vnuopc_Ly5" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -634,7 +634,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly3" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="ERS_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -646,7 +646,7 @@
 
     </machines>
   </test>
-  <test name="ERS_Vnuopc_Ly3" grid="f09_g17_gl4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="ERS_Vnuopc_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
 
       <machine name="cheyenne" compiler="gnu" category="aux_glc">
@@ -692,7 +692,7 @@
        coupling).
   -->
 
-  <test name="SMS_Ly2" grid="f09_g17_gl20" compset="T1850Gg">
+  <test name="SMS_Ly2" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">
@@ -704,7 +704,7 @@
     </machines>
   </test>
 
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
+  <test name="SMS_Ld5" grid="T31_g37_gris20" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
 
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines">

--- a/doc/source/b-compsets.rst
+++ b/doc/source/b-compsets.rst
@@ -179,7 +179,7 @@ CISM Topography Updating Workflow
 
 2. Create your case. When you create your case you will need to add the flag ``--workflow topo_regen_10yr_cycle`` . For example: ::
 
-     ./create_newcase --case Test_topo_regen_workflow_m03 --compset B1850G --res f09_g17_gl4 --workflow topo_regen_10yr_cycle --project P93300606 --run-unsupported
+     ./create_newcase --case Test_topo_regen_workflow_m03 --compset B1850G --res f09_g17_gris4 --workflow topo_regen_10yr_cycle --project P93300606 --run-unsupported
 
 3. Go into your new case directory and run ``./case.setup`` you should see a warning that says "Input template file /glade/scratch/katec/Test_topo_regen_workflow_m03/bld/../run/dynamic_atm_topo/template.topo_regen for job case.topo_regen does not exist or cannot be read." If you don't see a warning like this for your case than something has gone wrong. Check that you did the first two steps correctly.
 

--- a/doc/source/running-and-modifying.rst
+++ b/doc/source/running-and-modifying.rst
@@ -117,11 +117,11 @@ grid. For example, ``f09_g17`` runs the atmosphere and land on a 0.9\ |deg|\ x1.
 finite-volume grid and the ocean and sea ice on a displaced Greenland pole 1\ |deg|
 grid. If you don't specify the CISM grid explicitly in the grid alias, it will use the
 default grid (4 km). For some common grids, you can also specify the grid explicitly in
-the alias, using a ``_gl`` element following the ocean grid. For example, for a compset
-with CISM2, ``f09_g17_gl4`` is equivalent to ``f09_g17``.
+the alias, using a ``_gris`` element following the ocean grid. For example, for a compset
+with CISM2, ``f09_g17_gris4`` is equivalent to ``f09_g17``.
 
 For the T1850Gg compset (described in :numref:`t-compsets`), you should use grid
-``f09_g17_gl4``. For information on introducing new ice sheet grids, see :ref:`new-grids`.
+``f09_g17_gris4``. For information on introducing new ice sheet grids, see :ref:`new-grids`.
 
 Special considerations for hybrid cases
 ---------------------------------------

--- a/doc/source/t-compsets.rst
+++ b/doc/source/t-compsets.rst
@@ -50,7 +50,7 @@ grid, would look like:
 
 .. code-block:: console
 
-   ./create_newcase --case my_t_case --compset T1850Gg --res f09_g17_gl4
+   ./create_newcase --case my_t_case --compset T1850Gg --res f09_g17_gris4
 
 .. _t-with-your-own-data:
 
@@ -133,7 +133,7 @@ resolutions of the T compset run (as specified by the ``--res`` flag to
 ``create_newcase``) should match the resolution of the run used to create the forcing
 data. You *can* run with a different glc resolution than the one used to create the
 forcing data. So, for example, if you created the forcing data from an I or B compset with
-resolution ``f09_g17_gl4``, the T compset run should use resolution ``f09_g17_xxx``, where
+resolution ``f09_g17_gris4``, the T compset run should use resolution ``f09_g17_xxx``, where
 any value of ``xxx`` is acceptable.
 
 The following variables in ``env_run.xml`` should be modified appropriately for your


### PR DESCRIPTION
Rename "gland" to "gris" in grid specification. This way we will consistently use "gris" when referring to the Greenland ice sheet.

Note that this depends on the changes in https://github.com/ESMCI/cime/pull/3943