### PR TITLE
Update externals (nuopc now the default!) and test list

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,58 @@ This file describes what tags were created on master and why
 
 ================================================================================
 Originator: sacks
+Date: September 29, 2021
+Version: cismwrap_2_1_92
+One-line summary: Update externals (nuopc now the default!) and test list
+
+Purpose of changes:
+
+   - Update externals to versions tentatively planned for
+     cesm2_3_beta06. A key change here is to make nuopc the default
+     driver.
+
+   - Rework test names now that nuopc is the default driver (so _Vmct is
+     needed explicitly, _Vnuopc is not)
+
+   - Add a few more nuopc tests, now that nuopc is working on izumi_nag
+     (partially addresses
+     https://github.com/ESCOMP/CISM-wrapper/issues/60)
+
+   - Fix for build issue on izumi_nag
+
+Standalone checkout supported in this tag (Yes/No): Yes
+   (If yes, this implies that we expect to be able to build and run a
+   case from a standalone checkout using manage_externals, and for this
+   to continue to work long-term. The answer may be "No" if the set of
+   externals pointed to by manage_externals is broken, or if at least
+   one external points to a temporary branch that is may be deleted in
+   the near future.)
+
+   If No: Notes on externals used for testing:
+
+Changes answers relative to previous tag: Not investigated: all test
+names have changed
+
+   All baseline comparisons failed due to changes in test names.
+   However, note that the only substantive changes in this tag are
+   externals updates, so if there are any answer changes, they arise
+   from the change in externals.
+
+Bugs fixed (include github issue number):
+- Partially addresses ESCOMP/CISM-wrapper#60 (Once nuopc/cmeps cases
+  work on izumi, add some testing)
+
+Summary of testing:
+
+   Full aux_glc test suite on cheyenne and izumi.
+
+   Most testing was done on a8a3a5d6; just reran izumi_nag tests on
+   latest change (which removed an unused variable).
+
+   Baselines not compared due to changes in all test names.
+
+================================================================================
+Originator: sacks
 Date: September 14, 2021
 Version: cismwrap_2_1_91
 One-line summary: Fixes for Antarctica

--- a/Externals_CISM.cfg
+++ b/Externals_CISM.cfg
@@ -2,8 +2,7 @@
 local_path = source_cism
 protocol = git
 repo_url = https://github.com/ESCOMP/cism
-# This hash is on branch glad_get_nzocn, a bit past cism_main_2.01.008
-hash = 85cf4f5b46d6c5edfc5dba9142aea9ad7b3ed28e
+tag = cism_main_2.01.009
 required = True
 
 [externals_description]

--- a/Externals_CISM.cfg
+++ b/Externals_CISM.cfg
@@ -2,7 +2,8 @@
 local_path = source_cism
 protocol = git
 repo_url = https://github.com/ESCOMP/cism
-tag = cism_main_2.01.008
+# This hash is on branch glad_get_nzocn, a bit past cism_main_2.01.008
+hash = 85cf4f5b46d6c5edfc5dba9142aea9ad7b3ed28e
 required = True
 
 [externals_description]

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -149,6 +149,12 @@
     </machines>
   </test>
 
+  <!-- BUG(wjs, 2021-09-29, ESCOMP/CISM-wrapper#60) This currently fails
+       at namelist generation time, with "ERROR: for TG compset require
+       that lnd_cpl_time equal glc_cpl_time". If I remember correctly,
+       Mariana Vertenstein has fixed this issue on a branch of CMEPS.
+       Once it is working, we should restore this test. -->
+  <!--
   <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
     <machines>
 
@@ -161,6 +167,7 @@
 
     </machines>
   </test>
+  -->
 
   <test name="ERI_Vmct_N2_Ly9" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -149,6 +149,19 @@
     </machines>
   </test>
 
+  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
+    <machines>
+
+      <machine name="cheyenne" compiler="intel" category="aux_glc">
+        <options>
+          <option name="wallclock">0:30</option>
+          <option name="comment">ice evolution off is the typical operation of cism within cesm, so test that configuration</option>
+        </options>
+      </machine>
+
+    </machines>
+  </test>
+
   <test name="ERI_Vmct_N2_Ly9" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 

--- a/drivers/cpl/nuopc/glc_comp_nuopc.F90
+++ b/drivers/cpl/nuopc/glc_comp_nuopc.F90
@@ -229,7 +229,6 @@ contains
     type(ESMF_Time)         :: startTime             ! Start time
     type(ESMF_Time)         :: stopTime              ! Stop time
     type(ESMF_TimeInterval) :: timeStep              ! Model timestep
-    type(ESMF_Calendar)     :: esmf_calendar         ! esmf calendar
     type(ESMF_CalKind_Flag) :: esmf_caltype          ! esmf calendar type
     type(ESMF_vm)           :: vm                    ! esmf virtual machine structure
     integer                 :: ref_tod               ! reference time of day (sec)

--- a/source_glc/glc_InitMod.F90
+++ b/source_glc/glc_InitMod.F90
@@ -90,7 +90,7 @@
    use glimmer_log
    use glc_route_ice_runoff, only: set_routing
    use glc_history, only : glc_history_init, glc_history_write
-   use glc_indexing, only : glc_indexing_init, nx, ny
+   use glc_indexing, only : glc_indexing_init, nx, ny, nzocn
    use shr_file_mod, only : shr_file_getunit, shr_file_freeunit
    use esmf, only : ESMF_Clock
 
@@ -332,7 +332,7 @@
 
   call glc_indexing_init(ice_sheet, instance_index = 1)
   
-  call glc_allocate_fields(nx, ny)
+  call glc_allocate_fields(nx, ny, nzocn)
 
   tsfc(:,:) = 0._r8
   qsmb(:,:) = 0._r8

--- a/source_glc/glc_fields.F90
+++ b/source_glc/glc_fields.F90
@@ -66,7 +66,7 @@ module glc_fields
 ! !IROUTINE: glc_allocate_fields
 ! !INTERFACE:
 
- subroutine glc_allocate_fields (nx, ny)
+ subroutine glc_allocate_fields (nx, ny, nzocn)
 
 ! !DESCRIPTION:
 !  Allocate fields declared here
@@ -84,7 +84,7 @@ module glc_fields
 ! !INPUT/OUTPUT PARAMETERS:
 
    integer (i4), intent(in) :: &
-        nx, ny           ! grid dimensions
+        nx, ny, nzocn           ! grid dimensions
 
 !EOP
 !BOC
@@ -93,8 +93,8 @@ module glc_fields
    allocate(tsfc(nx,ny))
    allocate(qsmb(nx,ny))
    ! ktc temporary
-   allocate(salinity(1,nx,ny))
-   allocate(tocn(1,nx,ny))
+   allocate(salinity(nzocn,nx,ny))
+   allocate(tocn(nzocn,nx,ny))
 
    ! to coupler
    allocate(ice_covered(nx,ny))

--- a/source_glc/glc_indexing.F90
+++ b/source_glc/glc_indexing.F90
@@ -34,6 +34,7 @@ module glc_indexing
   integer, public :: nx_tot   ! total number of columns in full grid (all procs)
   integer, public :: ny_tot   ! total number of rows in full grid (all procs)
   integer, public :: npts_tot ! total number of points in full grid (all procs)
+  integer, public :: nzocn    ! number of ocean levels for ocean coupling fields
 
   integer, allocatable, private :: local_indices(:,:)  ! mapping from (i,j) to 1..npts
   integer, allocatable, private :: global_indices(:,:) ! unique indices across all procs (matches indexing on mapping files)
@@ -50,7 +51,7 @@ contains
     ! that is used to generate GLC mapping files for the coupler.
     !
     ! !USES:
-    use glad_main, only : glad_params, glad_get_grid_size, glad_get_grid_indices
+    use glad_main, only : glad_params, glad_get_grid_size, glad_get_grid_indices, glad_get_nzocn
     !
     ! !ARGUMENTS:
     type(glad_params), intent(in) :: params
@@ -65,9 +66,11 @@ contains
          ewn = nx, nsn = ny, npts = npts, &
          ewn_tot = nx_tot, nsn_tot = ny_tot, npts_tot = npts_tot)
     
+    call glad_get_nzocn(params, instance_index, nzocn)
+
     allocate(local_indices(nx, ny))
     allocate(global_indices(nx, ny))
-    
+
     call glad_get_grid_indices(params, instance_index, global_indices, local_indices)
     
   end subroutine glc_indexing_init


### PR DESCRIPTION
   - Update externals to versions tentatively planned for
     cesm2_3_beta06. A key change here is to make nuopc the default
     driver.

   - Rework test names now that nuopc is the default driver (so _Vmct is
     needed explicitly, _Vnuopc is not)

   - Add a few more nuopc tests, now that nuopc is working on izumi_nag
     (partially addresses
     https://github.com/ESCOMP/CISM-wrapper/issues/60)

   - Fix for build issue on izumi_nag
