### PR TITLE
Add documentation on multiple ice sheets

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -48,23 +48,16 @@ _CISM_CONFIG_GROUPS = ["grid", "glad_climate", "esm_output", "options", "sigma",
 # we use an OrderedDict to get reliable ordering (this is unnecessary in python3.6 and
 # later because standard dicts maintain order, but necessary for 3.5 and earlier)
 #
-# It is important that this ordering be consistent with the ordering of grids in CIME's config_grids xml file.
+# It is important that this ordering be consistent with the ordering of grids in the
+# config_grids xml file (e.g., if the Antarctica grid is listed before the Greenland grid
+# in grids defined in that file, then Antarctica must appear before Greenland in this
+# variable).
 #
 # Problems may arise if one ice sheet's name is a prefix of another (e.g., "gris" and "grisa").
 #
-# If you add a new ice sheet here, you should also add entries in the following:
-#
-# Required:
-# - cime_config/config_component.xml (xml variables for each ice sheet and their
-#   relationship to compset names; follow the examples of other ice sheets there)
-# - cime_config/namelist_definition_cism.xml (defaults for this ice sheet for ice
-#   sheet-specific variables)
-# - cime_config/config_archive.xml (add a new rpointer section for the new ice sheet, as
-#   well as rpointer test file entries for this new ice sheet)
-#
-# Optional:
-# - cime_config/config_compsets.xml (compset aliases using your new ice sheet)
-# - cime_config/config_pes.xml (default processor layouts for your new ice sheet)
+# If you add a new ice sheet here, you should also add references to the new ice sheet in
+# a number of other places, as described in the documentation here:
+#   https://escomp.github.io/cism-docs/cism-in-cesm/versions/master/html/new-icesheet.html
 _ICESHEET_OPTIONS = OrderedDict([('ais', 'ANTARCTICA'),
                                  ('gris', 'GREENLAND')])
 

--- a/doc/source/b-compsets.rst
+++ b/doc/source/b-compsets.rst
@@ -1,8 +1,8 @@
 .. _b-compsets:
 
-**************************************************************
+*****************************************************************
 Running the fully-coupled ice sheet model within CESM: B compsets
-**************************************************************
+*****************************************************************
 
 CISM is available to run as part of a fully coupled climate system 
 simulation in CESM 2.0. Runs with all active components are known 
@@ -12,8 +12,8 @@ compsets run with CISM in no-evolve mode, and compsets that end
 with G (e.g., "B1850G") have an active, or evolving, CISM 
 Greenland ice sheet. 
 
-Any compset, including B compsets, can turn on an actively evolving 
-CISM ice sheet model using the xml variable CISM_EVOLVE to TRUE.
+Any compset that includes CISM in no-evolve mode, including B compsets, can turn on an actively evolving 
+CISM ice sheet model by setting the xml variables ``CISM_EVOLVE_ICESHEET`` (for each included icesheet --- e.g., ``CISM_EVOLVE_GREENLAND``) as well as the overall ``CISM_EVOLVE`` to ``TRUE``.
 
 The sections below give links to information about CISM's coupling, 
 and how to start and run a CESM case in general. After the links 
@@ -29,18 +29,18 @@ method of updating the atmosphere topography to reflect the current
 shape of the ice sheet has been developed. That method is outlined 
 below. 
 
-===========
+======================================
 Helpful links for coupling information
-===========
+======================================
 
 - `Details of CISM, CLM and POP coupling <https://escomp.github.io/cism-docs/cism-in-cesm/versions/release-cesm2.0/html/clm-cism-coupling.html#>`_
 - `Generating Forcing Data to use in a CISM T compset <https://escomp.github.io/cism-docs/cism-in-cesm/versions/release-cesm2.0/html/t-compsets.html#performing-a-run-to-create-forcing-data>`_
 - `CESM Case Control System (how to setup, build, and run an experiment with CESM 2) <https://esmci.github.io/cime/versions/master/html/users_guide/index.html>`_
 - `User questions and answers in the DiscussCESM Forums <https://bb.cgd.ucar.edu/cesm/>`_
 
-===========
+===============
 CISM Time Steps
-===========
+===============
 
 There are a few different kinds of timesteps in CISM:
 
@@ -118,7 +118,7 @@ currently namelist and source modifications needed. Contact a LIWG scientist
 for more information about these.
 
 The time options below (apart from the forcing timestep) are set in
-*cism.config*. This file contains (or may contain) the following
+*cism.ICESHEET.config* for each ice sheet. This file contains (or may contain) the following
 timestep information:
 
 1. The ice sheet timestep *dt* (in years) is set in the section
@@ -134,47 +134,47 @@ timestep information:
 Note that the total length of the simulation is not determined by
 CISM, but is set in the file *env\_run.xml* in the case directory.
 
-===========
+=================================
 CISM Topography Updating Workflow
-===========
+=================================
 
 ** These instructions require CESM 2.1.1 or greater. **
 
 1. Edit your ``config_workflow.xml`` file. This is found in ``cime/config/cesm/machines`` . You will need to add the following code to this file anywhere after a ``</workflow_jobs>`` tag. ::
 
-  <workflow_jobs id="topo_regen_10yr_cycle">
-    <!-- order matters, jobs will be run in the order listed here -->
-    <job name="case.run">
-      <template>template.case.run</template>
-      <prereq>$BUILD_COMPLETE and not $TEST</prereq>
-    </job>
-    <job name="case.test">
-      <template>template.case.test</template>
-      <prereq>$BUILD_COMPLETE and $TEST</prereq>
-    </job>
-    <job name="case.topo_regen">
-      <template>$EXEROOT/../run/dynamic_atm_topo/template.topo_regen</template>
-      <!-- If case.run (or case.test) exits successfully then run topo_regen-->
-      <dependency>case.run or case.test</dependency>
-      <prereq>1</prereq>
-      <runtime_parameters>
-        <task_count>1</task_count>
-        <tasks_per_node>1</tasks_per_node>
-        <walltime>0:45:00</walltime>
-      </runtime_parameters>
-    </job>
-    <job name="case.st_archive">
-      <template>template.st_archive</template>
-      <!-- If case.topo_regen exits successfully then run st_archive-->
-      <dependency>case.topo_regen</dependency>
-      <prereq>$DOUT_S</prereq>
-      <runtime_parameters>
-        <task_count>1</task_count>
-        <tasks_per_node>1</tasks_per_node>
-        <walltime>0:20:00</walltime>
-      </runtime_parameters>
-    </job>
-  </workflow_jobs>
+    <workflow_jobs id="topo_regen_10yr_cycle">
+      <!-- order matters, jobs will be run in the order listed here -->
+      <job name="case.run">
+        <template>template.case.run</template>
+        <prereq>$BUILD_COMPLETE and not $TEST</prereq>
+      </job>
+      <job name="case.test">
+        <template>template.case.test</template>
+        <prereq>$BUILD_COMPLETE and $TEST</prereq>
+      </job>
+      <job name="case.topo_regen">
+        <template>$EXEROOT/../run/dynamic_atm_topo/template.topo_regen</template>
+        <!-- If case.run (or case.test) exits successfully then run topo_regen-->
+        <dependency>case.run or case.test</dependency>
+        <prereq>1</prereq>
+        <runtime_parameters>
+          <task_count>1</task_count>
+          <tasks_per_node>1</tasks_per_node>
+          <walltime>0:45:00</walltime>
+        </runtime_parameters>
+      </job>
+      <job name="case.st_archive">
+        <template>template.st_archive</template>
+        <!-- If case.topo_regen exits successfully then run st_archive-->
+        <dependency>case.topo_regen</dependency>
+        <prereq>$DOUT_S</prereq>
+        <runtime_parameters>
+          <task_count>1</task_count>
+          <tasks_per_node>1</tasks_per_node>
+          <walltime>0:20:00</walltime>
+        </runtime_parameters>
+      </job>
+    </workflow_jobs>
 
 
 2. Create your case. When you create your case you will need to add the flag ``--workflow topo_regen_10yr_cycle`` . For example: ::

--- a/doc/source/clm-cism-coupling.rst
+++ b/doc/source/clm-cism-coupling.rst
@@ -14,11 +14,10 @@ Non-evolving ice sheet
 In typical CESM runs, CISM is not evolving; CLM computes the ice sheet surface mass
 balance and sends it to CISM, but CISM's ice sheet geometry remains fixed over the course
 of the run, and CISM does not send any fluxes to other CESM components. These
-configurations use compsets with ``CISM2%NOEVOLVE`` in their long name (or this can be set
-after setting up a case via the xml variable, ``CISM_EVOLVE``). In these runs, CISM serves
+configurations use compsets with ``CISM2%XXX-NOEVOLVE`` in their long name (for some ice sheet ``XXX``). In these runs, CISM serves
 two roles in the system:
 
-#. Over the CISM domain (typically Greenland in CESM2), CISM dictates
+#. Over the CISM domain(s) (typically Greenland in CESM2), CISM dictates
    glacier areas and topographic elevations, overriding the values on
    CLM's surface dataset. CISM also dictates the elevation of
    non-glacier land units in its domain, and only in this domain are
@@ -30,8 +29,8 @@ two roles in the system:
 Evolving ice sheet with two-way (interactive) coupling
 ------------------------------------------------------
 
-Dynamic ice sheet evolution can be turned on by using a compset with ``CISM2%EVOLVE`` in
-its long name, or by setting the xml variable ``CISM_EVOLVE`` after setting up a case. In
+Dynamic ice sheet evolution can be turned on by using a compset with ``CISM2%XXX-EVOLVE`` in
+its long name (for some ice sheet ``XXX``), or by setting the xml variables ``CISM_EVOLVE_ICESHEET`` (for one or more instances of ``ICESHEET``) and the overall ``CISM_EVOLVE`` after setting up a case. In
 this configuration, CISM sends updated glacier areas and topographic elevations to CLM at
 the end of each year. In addition, CISM sends fluxes of ice and liquid water to the
 ocean. CLM responds to these changes by adjusting the areas of the glacier land unit and
@@ -57,8 +56,7 @@ Evolving ice sheet with one-way (diagnostic) coupling
 -----------------------------------------------------
 
 A hybrid mode is also possible, in which CISM evolves dynamically but does not feed back
-to the rest of the system. This configuration is enabled by turning on CISM evolution (via
-using a ``CISM2%EVOLVE`` compset or changing the ``CISM_EVOLVE`` xml variable to
+to the rest of the system. This configuration is enabled by turning on CISM evolution (by using a ``CISM2%XXX-EVOLVE`` compset or changing the relevant ``CISM_EVOLVE_ICESHEET`` and overall ``CISM_EVOLVE`` xml variables to
 ``TRUE``), but then changing the xml variable ``GLC_TWO_WAY_COUPLING`` to ``FALSE``. This
 change results in changes to CLM and CISM:
 
@@ -79,7 +77,7 @@ Stub GLC model (CISM absent)
 ----------------------------
 
 It is also possible to run CESM with a stub glacier model rather than CISM by using
-compsets with ``SGLC`` in place of ``CISM2%NOEVOLVE``. These configurations are similar to
+compsets with ``SGLC`` in place of ``CISM2%XXX-NOEVOLVE``. These configurations are similar to
 those with a non-evolving ice sheet, with the following differences:
 
 #. CLM's glacier areas and elevations will be taken entirely from CLM's initial conditions
@@ -445,10 +443,8 @@ This mask is currently a subset of the ice sheet grid mask. Currently, it is ide
 the ice sheet grid mask if we are running with an evolving, two-way-coupled ice sheet, and
 otherwise is zero everywhere (and, as described in :numref:`ice_sheet_grid_mask`, this
 relationship should remain true, because the ice sheet grid mask is used in the coupler in
-a way that closely matches the use of this second mask). In the future, when we allow
-multiple ice sheets in CESM (e.g., Greenland and Antarctica), it is possible that one ice
-sheet will operate two-way-coupled while another is one-way-coupled. In this case, this
-mask would match the ice sheet grid mask for the two-way-coupled ice sheet and would be
+a way that closely matches the use of this second mask). One reason this is sent as a separate field is to handle the scenario where there are multiple ice sheets (e.g., Greenland and Antarctica), with one ice sheet operating two-way-coupled while another is one-way-coupled. In this case, this
+mask matches the ice sheet grid mask for the two-way-coupled ice sheet and is
 zero for the other.
 
 Note that, like the ice sheet grid mask, this mask excludes CISM's open ocean grid
@@ -604,6 +600,8 @@ by up to 10%.  If we used conservative rather than bilinear remapping, differenc
 because of area distortions on CISM's polar stereographic grid.
 Thus the local errors for bilinear remapping and renormalization are similar to the local errors for conservative remapping.
 Bilinear remapping, however, is far smoother; smoothness is obtained at the cost of local conservation.
+
+When running with multiple ice sheets, the conservation correction is applied independently for each ice sheet. This means that the SMB over one ice sheet does *not* impact the renormalized SMB over another ice sheet.
 
 Remapping surface temperature from CLM to CISM
 ----------------------------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -34,6 +34,7 @@ Appendices
    :maxdepth: 2
 
    new-grids.rst
+   new-icesheet.rst
 
 ----
 

--- a/doc/source/introduction.rst
+++ b/doc/source/introduction.rst
@@ -297,3 +297,9 @@ in CESM for land-ice modeling:
 - See the other sections of this document for more detailed descriptions of new land-ice
   capabilities.
 
+===================================
+ Significant changes since CESM2.0
+===================================
+
+CESM2.0 only allowed running a single ice sheet at a time. Since then, CISM and the CESM infrastructure have
+been extended to allow running multiple ice sheets in a single simulation. There is out-of-the-box support for running Greenland and Antarctica, but other ice sheets can be added as well.

--- a/doc/source/new-grids.rst
+++ b/doc/source/new-grids.rst
@@ -9,7 +9,7 @@ Introducing a new ice sheet grid
 ********************************
 
 This section describes what is needed when introducing a new ice sheet grid into the
-system. Much of the information in :ref:`Generating mapping files` is also relevant when
+system. This assumes you are adding a grid for an existing ice sheet: If you are adding a completely new ice sheet (i.e., an ice sheet other than Greenland or Antarctica), see :ref:`new-icesheet`. Much of the information in :ref:`Generating mapping files` is also relevant when
 introducing a new land grid (in which case new lnd-glc mapping files are needed) or a new
 ocean grid (in which case new ocn-glc mapping files are needed).
 
@@ -319,6 +319,8 @@ Generating the necessary inter-component mapping files
 Generating lnd <-> glc mapping files for a new CISM grid
 --------------------------------------------------------
 
+**Note: this step is no longer necessary with the NUOPC/CMEPS interface, where lnd <-> glc mappings are now generated at runtime. (The glc -> ocn mapping files described in the next section ARE still needed.)**
+
 #. Build the check_maps tool
 
    This isn't entirely necessary, but allows the maps you generate to be checked
@@ -606,6 +608,8 @@ scripts, you need to add entries in config_grids.xml
 
 #. Point to new mapping files: lnd <-> glc
 
+   **Note: this step is no longer necessary with the NUOPC/CMEPS interface, where lnd <-> glc mappings are now generated at runtime. (The glc -> ocn mapping files described in the next step ARE still needed.)**
+   
    You'll need to add a section like this for each land grid, in the section
    "lnd to glc and glc to lnd mapping":
 

--- a/doc/source/new-icesheet.rst
+++ b/doc/source/new-icesheet.rst
@@ -1,0 +1,50 @@
+.. sectnum::
+   :prefix: A.
+   :start: 2
+
+.. _new-icesheet:
+
+*****************************
+ Introducing a new ice sheet
+*****************************
+
+This section describes what is needed when introducing support for a completely new ice sheet --- i.e., an ice sheet other than Greenland or Antarctica. If you are instead adding a new grid for an existing ice sheet (e.g., a new Greenland or Antarctica grid), see :ref:`new-grids`.
+
+=============================================
+Changes needed in the CISM-wrapper repository
+=============================================
+
+The following changes are needed so that you can create a compset with a new ice sheet and have an appropriate ``cism.ICESHEET.config`` file generated for the new ice sheet:
+
+#. Add an entry to the ``_ICESHEET_OPTIONS`` variable in the ``buildnml`` file (in the ``cime_config`` directory of the CISM-wrapper repository). Each ice sheet has two names associated with it: a short, lowercase name (e.g., ``ais``) and a full, uppercase name (e.g., ``ANTARCTICA``). Both names are given in the ``_ICESHEET_OPTIONS`` variable. The short name is used in the grid specification, the ``user_nl_cism`` file name, the config file name, and various other file names; the full name is used in some XML variables. **It is important that the ordering of ice sheets in _ICESHEET_OPTIONS is consistent with the ordering of grids in the config_grids xml file (e.g., if the Antarctica grid is listed before the Greenland grid in grids defined in that file, then Antarctica must appear before Greenland in this variable). Also, avoid having one ice sheet's name be a prefix of another (e.g., "gris" and "grisa").**
+
+#. Add entries in ``cime_config/config_component.xml`` giving XML variables for the new ice sheet and their relationship with compset long names. Follow the examples of other ice sheets in that file (e.g., do a case-insensitive search for "Antarctica" in that file).
+
+#. Add entries in ``cime_config/namelist_definition_cism.xml`` to add default configuration values for this ice sheet for any variables whose defaults differ between ice sheets. At a minimum, look for any variable in that file that already has a ``<value>`` entry with an ``icesheet`` attribute --- e.g., ``<value icesheet="gris">`` or ``<value icesheet="ais">`` --- and add a new entry for the new ice sheet; sometimes a specific grid might also be needed as an additional attribute. Optionally, there may be some additional variables that currently have the same default value for all ice sheets but for which you want a different default for the new ice sheet; for these, you can replace the single ``<value>`` entry with new ``<value icesheet="xxx">`` entries for each ice sheet.
+
+#. Add entries in ``cime_config/config_archive.xml``: add a new rpointer section for the new ice sheet, as well as rpointer test file entries for this new ice sheet. (You can search for "ais" in that file to see what is needed.)
+
+#. [OPTIONAL] Add one or more new compset aliases in ``cime_config/config_compsets.xml`` using the new ice sheet. Note that only T compsets are defined here; other compsets are defined in other ``config_compsets.xml`` files elsewhere in CESM.
+
+#. [OPTIONAL] Add one or more default processor layouts in ``cime_config/config_pes.xml`` for the new ice sheet. Note that only processor layouts for T compsets are defined here; processor layouts for other compsets are defined in other ``config_pes.xml`` files elsewhere in CESM.
+
+====================================
+Changes needed in other repositories
+====================================
+
+A number of changes are also needed in other repositories to specify the new CISM grid(s). (See also :ref:`new-grids`.)
+
+..
+    In the following references to the ccs_config_cesm repository, I don't mention the specific file(s) to modify because this new repository is in a state of flux, so any reference to specific files may soon be out of date.
+
+#. In the appropriate XML file in https://github.com/ESMCI/ccs_config_cesm add one or more grid definitions for this ice sheet. This involves adding a ``<domain>`` entry (which specifies the dimensions of the grid and an ESMF mesh file that defines the grid) and one or more ``<model_grid>`` entries (which specify grid aliases that can be used to run CISM with this grid together with certain atmosphere/land and ocean grids, possibly in conjunction with other CISM grids if you want to run multiple ice sheets in a single simulation). As with other changes, it is easiest to follow the example of an existing CISM grid; for example, search for "ais8" to see what your additions should look like.
+
+#. [OPTIONAL] To enable fully-coupled (B compset) runs, additional changes are needed in https://github.com/ESMCI/ccs_config_cesm to specify runoff mapping files from the new CISM grid(s) to the desired ocean grid(s). (Mapping files between CISM and other components do not need to be specified, since they will be generated at runtime.) Once again, search for "ais8" to see what your additions should look like.
+
+#. In CTSM, set up an appropriate glacier region (see :ref:`new-grids` for details).
+
+===================================
+Caveats when adding a new ice sheet
+===================================
+
+**In a run with multiple ice sheets, it is very important that the grids for the different ice sheets do not overlap.** In fact, the restriction is a bit more stringent: **There cannot be any land grid cell that intersects with multiple CISM domains.** This is because the lnd-glc mapping algorithms in CMEPS cannot handle the situation where a given land grid cell intersects with multiple CISM domains. This requirement is NOT checked in the code: it is the user's responsibility to ensure that it is satisfied.

--- a/doc/source/t-compsets.rst
+++ b/doc/source/t-compsets.rst
@@ -32,18 +32,11 @@ forcing data (see :numref:`t-with-your-own-data`).
  Running with existing forcing data
 ====================================
 
-There is currently just a single set of forcing data available for running T
-compsets. These forcing data were created with software testing rather than scientific
-validity in mind. They were created from 30 years of an ``I1850Clm50Sp`` compset (CLM
-forced by a data atmosphere with GSWP3 forcing, starting from an already-near-spun-up
-state, with nominally year-1850 forcings and satellite phenology). The resolution was
-``f09_g17``. The code base was close to the final CESM2.0 release. For more details, see
-`<https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/lnd/dlnd7/CPLHIST_SNO/i.e20.I1850Clm50Sp.f09_g17.001_c180502/README>`__.
+There is currently just a single set of out-of-the-box forcing data available for running T
+compsets. These forcing data were created from the B1850 CMIP6 PI-control run, at resolution ``f09_g17``.
 
-There is one out-of-the-box T compset that uses these forcing data: T1850Gg. **You should
-run this compset at f09_g17 resolution --- i.e., with the same land resolution and ocean
-mask used to create the forcing data.** You can use any CISM resolution, although the
-current forcing data only have complete forcings for Greenland, not Antarctica.
+There are three out-of-the-box T compsets that use these forcing data: ``T1850Gg`` (Greenland only), ``T1850Ga`` (Antarctica only), and ``T1850Gag`` (both Antarctica and Greenland). There is no scientific advantage to running both Antarctica and Greenland in the same T compset case, since the two ice sheets won't interact in this situation (in contrast to a coupled simulation, where it can be scientifically useful to run multiple ice sheets in the same simulation). Thus, the main reasons for using ``T1850Gag`` are for convenience or testing. With any of these compsets, **you should use f09_g17 resolution --- i.e., with the same land resolution and ocean
+mask used to create the forcing data.** You can use any CISM grid(s), although note that you must choose a resolution that specifies a grid for each active ice sheet (see :numref:`choosing-a-cism-grid`).
 
 So a typical ``create_newcase`` command when running with the standard 4-km Greenland
 grid, would look like:
@@ -72,7 +65,7 @@ To create the necessary forcing data (surface mass balance and surface temperatu
 glacier elevation class, along with surface elevation for the coupler's vertical
 downscaling), you need to perform a CESM run using a compset that includes an active land
 model (CLM). It does not matter whether the glc component is fully-active
-(``CISM2%EVOLVE``), active but non-evolving (``CISM2%NOEVOLVE``) or a stub model
+(e.g., ``CISM2%GRIS-EVOLVE``), active but non-evolving (e.g., ``CISM2%GRIS-NOEVOLVE``) or a stub model
 (``SGLC``). If running with CISM, CISM's domain and resolution also do not matter (because
 forcing data are saved prior to downscaling to the CISM grid).
 
@@ -134,7 +127,7 @@ resolutions of the T compset run (as specified by the ``--res`` flag to
 data. You *can* run with a different glc resolution than the one used to create the
 forcing data. So, for example, if you created the forcing data from an I or B compset with
 resolution ``f09_g17_gris4``, the T compset run should use resolution ``f09_g17_xxx``, where
-any value of ``xxx`` is acceptable.
+any value of ``xxx`` is acceptable. You can even run the T compset with a different ice sheet than the one(s) used to create the forcing data, as long as CLM's glacier regions and their behaviors were set up appropriately, as described above.
 
 The following variables in ``env_run.xml`` should be modified appropriately for your
 forcing data:


### PR DESCRIPTION
This is a documentation-only PR, adding documentation on running with multiple ice sheets. (There are small changes in buildnml, but only to comments in that file.)

I have:

1. Modified existing documentation to add notes about running with multiple ice sheets
2. Added a new appendix on what is needed to add a new ice sheet (**note: it's possible that I am missing some pieces here; I figure we can fill this in with anything missing whenever someone first attempts to follow these instructions and runs into trouble**)

I have built and pushed the documentation to the official documentation site (figuring there is little harm in updating this documentation with this draft version, even if we need to push a fixed version later): see https://escomp.github.io/cism-docs/cism-in-cesm/versions/master/html/index.html and especially the new section, https://escomp.github.io/cism-docs/cism-in-cesm/versions/master/html/new-icesheet.html . Besides the entirely new section, it might be helpful to skim through the changes in this PR to get a sense of where I made changes, but then actually look at the new documentation in the built documentation (which will be easier to read than the diffs in the source rst files).

@whlipscomb @gunterl @Katetc - I have added you all as reviewers in case you want to give this a formal review before I merge it to master. I'm happy to iterate with you to get the new documentation into a state where it's clear to others. But I'll leave it up to you as to whether you actually want to review this before I merge it; feel free to remove yourself as a reviewer if you don't feel a need to.