### PR TITLE
Advertise import fields even with noevolve

### DIFF
--- a/drivers/cpl/nuopc/glc_comp_nuopc.F90
+++ b/drivers/cpl/nuopc/glc_comp_nuopc.F90
@@ -194,7 +194,7 @@ contains
     ! Set filenames which depend on instance information
     call set_filenames()
 
-    ! Determine if cism will evolve - if not will not import any fields from the mediator
+    ! Determine if cism will evolve
     call NUOPC_CompAttributeGet(gcomp, name="cism_evolve", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     if (isPresent .and. isSet) then
@@ -214,7 +214,7 @@ contains
     end if
 
     ! Advertise fields
-    call advertise_fields(gcomp, cism_evolve, num_icesheets_from_mediator, rc)
+    call advertise_fields(gcomp, num_icesheets_from_mediator, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug > 5) then

--- a/drivers/cpl/nuopc/glc_import_export.F90
+++ b/drivers/cpl/nuopc/glc_import_export.F90
@@ -76,13 +76,12 @@ module glc_import_export
 contains
 !===============================================================================
 
-  subroutine advertise_fields(gcomp, cism_evolve, num_icesheets_in, rc)
+  subroutine advertise_fields(gcomp, num_icesheets_in, rc)
 
     use glc_constants, only : glc_smb
 
     ! input/output variables
     type(ESMF_GridComp)            :: gcomp
-    logical          , intent(in)  :: cism_evolve
     integer          , intent(in)  :: num_icesheets_in
     integer          , intent(out) :: rc
 
@@ -201,25 +200,26 @@ contains
     ! Advertise import fields
     !--------------------------------
 
-    if (cism_evolve) then
-       call fldlist_add(fldsToGlc_num, fldsToGlc, trim(flds_scalar_name))
-       call fldlist_add(fldsToGlc_num, fldsToGlc, field_in_tsrf)
-       call fldlist_add(fldsToGlc_num, fldsToGlc, field_in_qice)
+    ! Note that we advertise the import fields even if running with a non-evolving ice
+    ! sheet; this is needed for the MED -> GLC mapping to work (which we do even for a
+    ! non-evolving ice sheet).
+    call fldlist_add(fldsToGlc_num, fldsToGlc, trim(flds_scalar_name))
+    call fldlist_add(fldsToGlc_num, fldsToGlc, field_in_tsrf)
+    call fldlist_add(fldsToGlc_num, fldsToGlc, field_in_qice)
 
-       ! Now advertise import fields
-       do ns = 1,num_icesheets
-          do nf = 1,fldsToGlc_num
-             call NUOPC_Advertise(NStateImp(ns), standardName=fldsToGlc(nf)%stdname, &
-                  TransferOfferGeomObject='will provide', rc=rc)
-             if (chkErr(rc,__LINE__,u_FILE_u)) return
-             if (my_task == master_task) then
-                write(cnum,'(i0)') ns
-                write(stdout,'(a)') 'Advertised import field: '//trim(fldsToGlc(nf)%stdname)//' for ice sheet '//trim(cnum)
-             end if
-             call ESMF_LogWrite(subname//'Import field'//': '//trim(fldsToGlc(nf)%stdname), ESMF_LOGMSG_INFO)
-          end do
-       enddo
-    end if
+    ! Now advertise import fields
+    do ns = 1,num_icesheets
+       do nf = 1,fldsToGlc_num
+          call NUOPC_Advertise(NStateImp(ns), standardName=fldsToGlc(nf)%stdname, &
+               TransferOfferGeomObject='will provide', rc=rc)
+          if (chkErr(rc,__LINE__,u_FILE_u)) return
+          if (my_task == master_task) then
+             write(cnum,'(i0)') ns
+             write(stdout,'(a)') 'Advertised import field: '//trim(fldsToGlc(nf)%stdname)//' for ice sheet '//trim(cnum)
+          end if
+          call ESMF_LogWrite(subname//'Import field'//': '//trim(fldsToGlc(nf)%stdname), ESMF_LOGMSG_INFO)
+       end do
+    enddo
 
     ! Set glc_smb
     ! true  => get surface mass balance from land model via coupler (in multiple elev classes)


### PR DESCRIPTION
This is needed for the MED -> GLC mapping to work in https://github.com/ESCOMP/CMEPS/pull/442. So the changes here and the changes in that CMEPS PR are inter-dependent (though it *might* work to bring in these CISM-wrapper changes before those CMEPS changes; I haven't tested that).

I have tested this by running aux_glc on derecho (intel & gnu) on this branch along with the changes from https://github.com/ESCOMP/CMEPS/pull/442 cherry-picked onto cmeps0.14.43. Failures were as expected:

```
    FAIL ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve NLCOMP
    FAIL ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve BASELINE /glade/derecho/scratch/sacks/aux_glc_240301164745/baselines: DIFF
    FAIL NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu COMPARE_base_multiinst
    FAIL SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-noevolve NLCOMP
    FAIL SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-noevolve BASELINE /glade/derecho/scratch/sacks/aux_glc_240301164745/baselines: DIFF
```

(The NCK test fails on master, too.) I confirmed that the diffs are as expected.