### PR TITLE
Change CISM_USE_ICESHEET to GLC_USE_ICESHEET

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,45 @@ This file describes what tags were created on master and why
 ================================================================================
 
 ================================================================================
+Originator: sacks
+Date: April 3, 2024
+Version: cismwrap_2_1_99
+One-line summary: Change CISM_USE_ICESHEET to GLC_USE_ICESHEET
+
+Purpose of changes:
+
+Now DGLC defines similar variables. To keep the logic simple in CTSM
+(which uses these variables), we'll use GLC_USE_ICESHEET in both.
+
+For now also keeps CISM_USE_ICESHEET for backwards compatibility.
+
+Standalone checkout supported in this tag (Yes/No): Yes
+   (If yes, this implies that we expect to be able to build and run a
+   case from a standalone checkout using manage_externals, and for this
+   to continue to work long-term. The answer may be "No" if the set of
+   externals pointed to by manage_externals is broken, or if at least
+   one external points to a temporary branch that is may be deleted in
+   the near future.)
+
+   If No: Notes on externals used for testing:
+
+Changes answers relative to previous tag: NO
+
+Bugs fixed (include github issue number):
+
+	No documented issues addressed here.
+
+Summary of testing:
+
+   Full aux_glc test suite on Derecho only (intel + gnu). Generated new suite of baselines.
+
+   Failures are as expected:
+   - FAIL ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve COMPARE_base_rest
+     - See notes under cismwrap_2_1_98
+   - FAIL NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu COMPARE_base_multiinst
+     - Fails on master, too (not noted for earlier tags because derecho_gnu testing hasn't been run)
+
+================================================================================
 Originator: katetc
 Date: February 27, 2024
 Version: cismwrap_2_1_98

--- a/cime_config/SystemTests/multivssingle.py
+++ b/cime_config/SystemTests/multivssingle.py
@@ -37,7 +37,7 @@ class MULTIVSSINGLE(SystemTestsCompareTwo):
         """Initialize this test instance
 
         The following specify the ice sheet to turn off:
-        - remove_icesheet_xml_name is the name of the icesheet in xml variables like CISM_USE_* (e.g., GREENLAND)
+        - remove_icesheet_xml_name is the name of the icesheet in xml variables like GLC_USE_* (e.g., GREENLAND)
         - remove_icesheet_grid_name is the name of the icesheet in the grid name (e.g., gris)
         """
         self._remove_icesheet_xml_name = remove_icesheet_xml_name
@@ -67,6 +67,10 @@ class MULTIVSSINGLE(SystemTestsCompareTwo):
 
     def _case_two_setup(self):
         # Turn off the given ice sheet
+        self._case.set_value("GLC_USE_{}".format(self._remove_icesheet_xml_name), "FALSE")
+        # BACKWARDS_COMPATIBILITY(wjs,2024-04-01) Backwards compatibility with old CTSM
+        # versions that expect CISM_USE_ANTARCTICA (can be removed after
+        # https://github.com/ESCOMP/CTSM/pull/2449 is merged).
         self._case.set_value("CISM_USE_{}".format(self._remove_icesheet_xml_name), "FALSE")
         self._case.set_value("CISM_EVOLVE_{}".format(self._remove_icesheet_xml_name), "FALSE")
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -209,10 +209,10 @@ def _is_icesheet_present(case, icesheet_name):
 ####################################################################################
     """Returns True if the given ice sheet is present in this run, False otherwise
 
-    (This is based on the appropriate CISM_USE_* variable)
+    (This is based on the appropriate GLC_USE_* variable)
     """
     xmlname = _ICESHEET_OPTIONS[icesheet_name]
-    xmlvar = "CISM_USE_" + xmlname
+    xmlvar = "GLC_USE_" + xmlname
     return case.get_value(xmlvar)
 
 ####################################################################################

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -32,6 +32,55 @@
     <desc>Name of land ice-sheet component</desc>
   </entry>
 
+  <!-- We use names GLC_USE_GREENLAND and GLC_USE_ANTARCTICA (instead of CISM_USE_)
+  because DGLC also sets these variables and they are referenced by CTSM; by using the
+  same names for both CISM and DGLC, the CTSM logic remains simpler. -->
+  <entry id="GLC_USE_GREENLAND">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_component_cism</group>
+    <file>env_run.xml</file>
+    <values>
+      <value compset="_CISM[^_]*%GRIS">TRUE</value>
+
+      <!-- BACKWARDS_COMPATIBILITY(wjs, 2020-12-23) Backwards
+           compatibility with old compsets that don't explicitly set
+           Greenland or Antarctica: we assume these just use Greenland
+      -->
+      <value compset="_CISM2%EVOLVE_">TRUE</value>
+      <value compset="_CISM2%NOEVOLVE_">TRUE</value>
+    </values>
+    <desc>Whether to include the Greenland Ice Sheet in this CISM simulation
+
+    This should generally be set at create_newcase time (via the compset). In principle it
+    can be changed later, but great care is needed to change a number of other variables
+    to be consistent (GLC_GRID, GLC_DOMAIN_MESH, CISM_EVOLVE_GREENLAND, and possibly
+    others).
+    </desc>
+  </entry>
+
+  <entry id="GLC_USE_ANTARCTICA">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_component_cism</group>
+    <file>env_run.xml</file>
+    <values>
+      <value compset="_CISM[^_]*%AIS">TRUE</value>
+    </values>
+    <desc>Whether to include the Antarctica Ice Sheet in this CISM simulation
+
+    This should generally be set at create_newcase time (via the compset). In principle it
+    can be changed later, but great care is needed to change a number of other variables
+    to be consistent (GLC_GRID, GLC_DOMAIN_MESH, CISM_EVOLVE_ANTARCTICA, and possibly
+    others).
+    </desc>
+  </entry>
+
+  <!-- BACKWARDS_COMPATIBILITY(wjs,2024-04-01) Backwards compatibility with old CTSM
+  versions that expect CISM_USE_ANTARCTICA (can be removed after
+  https://github.com/ESCOMP/CTSM/pull/2449 is merged). -->
   <entry id="CISM_USE_GREENLAND">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -92,7 +92,7 @@ Sub-elements of each entry include:
     </desc>
   </entry>
 
-  <entry id="num_icesheets" skip_default_entry="true" modify_via_xml="CISM_USE_ANTARCTICA, CISM_USE_GREENLAND, etc.">
+  <entry id="num_icesheets" skip_default_entry="true" modify_via_xml="GLC_USE_ANTARCTICA, GLC_USE_GREENLAND, etc.">
     <type>integer</type>
     <category>cism</category>
     <group>cism_params</group>
@@ -102,7 +102,7 @@ Sub-elements of each entry include:
     </desc>
   </entry>
 
-  <entry id="icesheet_names" skip_default_entry="true" modify_via_xml="CISM_USE_ANTARCTICA, CISM_USE_GREENLAND, etc.">
+  <entry id="icesheet_names" skip_default_entry="true" modify_via_xml="GLC_USE_ANTARCTICA, GLC_USE_GREENLAND, etc.">
     <type>char(10)</type>
     <category>cism</category>
     <group>cism_params</group>


### PR DESCRIPTION
Now DGLC defines similar variables. To keep the logic simple in CTSM (which uses these variables), we'll use GLC_USE_ICESHEET in both.

For now also keeps CISM_USE_ICESHEET for backwards compatibility.

I'm going to test & merge this myself, per discussion with @Katetc , but opening this PR for visibility.

FYI - @ekluzek @mvertens