### PR TITLE
add timestamp to rpointer files

### DIFF
--- a/source_glc/glc_files.F90
+++ b/source_glc/glc_files.F90
@@ -99,7 +99,7 @@
 !-----------------------------------------------------------------------
 
      call get_inst_suffix(inst_suffix)
-     write(timestamp,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') '.',yr,'-',mon,'-',day,'-',tod
+     write(timestamp,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') '.',yr,'-',mon,'-',day,'-',tod
      ! NOTE(wjs, 2021-09-20) In other places, we put the ice sheet name *after* the instance
      ! number. However, I feel like there may be some code that assumes that, for rpointer
      ! files, the instance number comes last. In case my recollection is right about that

--- a/source_glc/glc_files.F90
+++ b/source_glc/glc_files.F90
@@ -74,7 +74,7 @@
 !BOP
 ! !IROUTINE: get_rpointer_filename
 ! !INTERFACE:
-   function get_rpointer_filename(icesheet_name) result(rpointer_filename)
+   function get_rpointer_filename(icesheet_name, yr, mon, day, tod, toread) result(rpointer_filename)
 !
 ! !DESCRIPTION:
 ! Get the filename for the rpointer file for the given ice sheet
@@ -85,21 +85,34 @@
 ! !ARGUMENTS:
      character(len=CL) :: rpointer_filename
      character(len=*), intent(in) :: icesheet_name
+     integer, intent(in) :: yr
+     integer, intent(in) :: mon
+     integer, intent(in) :: day
+     integer, intent(in) :: tod
+     logical, intent(in) :: toread
 !
 ! !LOCAL VARIABLES:
      character(len=16) :: inst_suffix
-!EOP
+     character(len=17) :: timestamp
+     logical :: exists
+     !EOP
 !-----------------------------------------------------------------------
 
      call get_inst_suffix(inst_suffix)
-
+     write(timestamp,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') '.',yr,'-',mon,'-',day,'-',tod
      ! NOTE(wjs, 2021-09-20) In other places, we put the ice sheet name *after* the instance
      ! number. However, I feel like there may be some code that assumes that, for rpointer
      ! files, the instance number comes last. In case my recollection is right about that
      ! (or in case anyone introduces code with that assumption), I am putting the instance
      ! number at the end of the rpointer file name.
-     rpointer_filename = 'rpointer.glc.'//trim(icesheet_name)//trim(inst_suffix)
-
+     rpointer_filename = 'rpointer.glc.'//trim(icesheet_name)//trim(inst_suffix)//timestamp
+     if(toread) then
+        inquire(file=trim(rpointer_filename), exist=exists)
+        if(.not. exists) then
+           rpointer_filename = 'rpointer.glc.'//trim(icesheet_name)//trim(inst_suffix)
+        endif
+     endif
+     
    end function get_rpointer_filename
 
 end module glc_files

--- a/source_glc/glc_io.F90
+++ b/source_glc/glc_io.F90
@@ -90,7 +90,7 @@
        modelymd = yr*10000+mon*100+day
        ! get restart filename from rpointer file
        ptr_unit = shr_file_getUnit()
-       open(ptr_unit,file=get_rpointer_filename(icesheet_name, yr, mon, day, tod))
+       open(ptr_unit,file=get_rpointer_filename(icesheet_name, yr, mon, day, tod, .true.))
        read(ptr_unit,'(a)') filename0
        filename = trim(filename0)
        close(ptr_unit)
@@ -509,7 +509,7 @@
     ! write pointer to restart file
     if (my_task == master_task) then
        ptr_unit = shr_file_getUnit()
-       open(ptr_unit,file=get_rpointer_filename(icesheet_name, cesmYR, cesmMON, cesmDAY, cesmTOD))
+       open(ptr_unit,file=get_rpointer_filename(icesheet_name, cesmYR, cesmMON, cesmDAY, cesmTOD, .false.))
        write(ptr_unit,'(a)') filename
        close(ptr_unit)
        call shr_file_freeunit(ptr_unit)


### PR DESCRIPTION
Add timestamps to the rpointer files - we would like this in cesm3_0_beta04.
I've tested the cesm3 beta test suite, in particular:
ERI_Ly15.f09_g17_gris4.T1850Gg.derecho_intel.cism-isostasy_period4
Thanks,