### PR TITLE
Katetc/cism wrapper 2 2 04

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,83 @@
 This file describes what tags were created on master and why
 ================================================================================
 
+Originator: jedwards & katetc
+Date: Oct 9, 2024
+Version: cismwrap_2_2_004
+One-line summary: Add timestamps to rpointer file names
+
+Purpose of changes:
+	Adds timestamps to the names of rpointer files so that specfic restarts
+	can be used. Needed for cesm3_0_beta04 and coordinated with other
+	components.
+
+Standalone checkout supported in this tag (Yes/No): Yes
+   (If yes, this implies that we expect to be able to build and run a
+   case from a standalone checkout using git-fleximod, and for this
+   to continue to work long-term. The answer may be "No" if the set of
+   externals pointed to by manage_externals is broken, or if at least
+   one external points to a temporary branch that is may be deleted in
+   the near future.)
+
+   If No: Notes on externals used for testing:
+
+Changes answers relative to previous tag: Does not change answers, but
+	see notes below about testing.
+
+Bugs fixed (include github issue number):
+
+	No documented issues addressed here.
+
+Summary of testing:
+
+	aux_glc test suite on Derecho for both Intel and Gnu run. Could not find
+	baselines for the cismwrap_2_2_002 tag in the expected locations. So,
+	had to compare against cismwrap_2_1_101, which had differences due to
+	the changes in 2_2_002. However, T-compsets cprnc verifies that all
+	answer fields remain b4b, just new fields added.
+
+	aux_glc/derecho/intel (compare against cismwrap_2_1_101):
+
+  ERI_Lm24.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-isostasy_period4 (Overall: DIFF) details:
+  ERI_Ly15.f09_g17_gris4.T1850Gg.derecho_intel.cism-isostasy_period4 (Overall: DIFF) details:
+  ERI_Ly44.f09_g17_gris20.T1850Gg.derecho_intel.cism-isostasy_period4 (Overall: DIFF) details:
+  ERS_D_Ly3.f09_g17_ais8gris4.T1850Gag.derecho_intel (Overall: DIFF) details:
+  ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-cmip6_evolving_icesheet (Overall: DIFF) details:
+  ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve (Overall: DIFF) details:
+  ERS_Lm24.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_intel (Overall: DIFF) details:
+  ERS_Ly3_C2_D.f09_g17_gris20.T1850Gg.derecho_intel (Overall: DIFF) details:
+  ERS_Ly3.f10_f10_ais8_mg37.I1850Clm50SpGa.derecho_intel (Overall: DIFF) details:
+  ERS_Ly3.f10_f10_mg37.I1850Clm50SpG.derecho_intel (Overall: DIFF) details:
+  ERS_Ly5.f09_g17_ais8.T1850Ga.derecho_intel (Overall: DIFF) details:
+  ERS_Ly7.f09_g17_gris4.T1850Gg.derecho_intel (Overall: DIFF) details:
+  MULTINOAIS_Ly2.f10_f10_ais8gris4_mg37.I1850Clm50SpRsGag.derecho_intel.cism-change_params (Overall: DIFF) details:
+  MULTINOGRIS_Ly2.f10_f10_ais8gris4_mg37.I1850Clm50SpRsGag.derecho_intel.cism-change_params (Overall: DIFF) details:
+  SMS_D_Ly1.f09_g17_ais8.T1850Ga.derecho_intel (Overall: DIFF) details:
+  SMS_D_Ly1.f09_g17_gris4.T1850Gg.derecho_intel.cism-isostasy_period1 (Overall: DIFF) details:
+  SMS_D_Ly1.f09_g17_gris4.T1850Gg.derecho_intel (Overall: DIFF) details:
+  SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-noevolve (Overall: DIFF) details:
+
+	aux_glc/derecho/gnu (compare against cismwrap_2_1_101):
+  ERI_C2_Ly9.f09_g17_ais8gris4.T1850Gag.derecho_gnu (Overall: DIFF) details:
+  ERI.f10_f10_mg37.I1850Clm50SpG.derecho_gnu.cism-test_coupling (Overall: DIFF) details:
+  ERI_Ly9.f09_g17_ais8gris4.T1850Gag.derecho_gnu.cism-noevolve_ais (Overall: DIFF) details:
+  ERS_D_Ld9.f10_f10_mg37.I1850Clm50SpG.derecho_gnu.cism-override_glc_frac (Overall: DIFF) details:
+  ERS_Ly11.f09_g17_gris20.T1850Gg.derecho_gnu.cism-oneway (Overall: DIFF) details:
+  ERS_Ly11.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: DIFF) details:
+  ERS_Ly3.f09_g17_gris4.T1850Gg.derecho_gnu.cism-isostasy_period1 (Overall: DIFF) details:
+  ERS_Ly5.f09_g17_gris4.T1850Gg.derecho_gnu.cism-isostasy_period4 (Overall: DIFF) details:
+  MCC_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: DIFF) details:
+
+	NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: FAIL) details:
+	FAIL NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu COMPARE_base_multiinst
+	** Expected failure ** See https://github.com/ESCOMP/CISM-wrapper/issues/110
+
+  SMS_D_Ld5.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_gnu.cism-test_coupling (Overall: DIFF) details:
+  SMS_D_Ly1.f09_g17_ais8.T1850Ga.derecho_gnu (Overall: DIFF) details:
+  SMS_D_Ly1.f09_g17_gris4.T1850Gg.derecho_gnu (Overall: DIFF) details:
+
+================================================================================
+
 Originator: jedwards
 Date: July 12, 2024
 Version: cismwrap_2_2_003

--- a/source_glc/glc_files.F90
+++ b/source_glc/glc_files.F90
@@ -99,7 +99,7 @@
 !-----------------------------------------------------------------------
 
      call get_inst_suffix(inst_suffix)
-     write(timestamp,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') '.',yr,'-',mon,'-',day,'-',tod
+     write(timestamp,'(a,i4.4,a,i2.2,a,i2.2,a,i5.5)') '.',yr,'-',mon,'-',day,'-',tod
      ! NOTE(wjs, 2021-09-20) In other places, we put the ice sheet name *after* the instance
      ! number. However, I feel like there may be some code that assumes that, for rpointer
      ! files, the instance number comes last. In case my recollection is right about that

--- a/source_glc/glc_files.F90
+++ b/source_glc/glc_files.F90
@@ -74,7 +74,7 @@
 !BOP
 ! !IROUTINE: get_rpointer_filename
 ! !INTERFACE:
-   function get_rpointer_filename(icesheet_name) result(rpointer_filename)
+   function get_rpointer_filename(icesheet_name, yr, mon, day, tod, toread) result(rpointer_filename)
 !
 ! !DESCRIPTION:
 ! Get the filename for the rpointer file for the given ice sheet
@@ -85,21 +85,34 @@
 ! !ARGUMENTS:
      character(len=CL) :: rpointer_filename
      character(len=*), intent(in) :: icesheet_name
+     integer, intent(in) :: yr
+     integer, intent(in) :: mon
+     integer, intent(in) :: day
+     integer, intent(in) :: tod
+     logical, intent(in) :: toread
 !
 ! !LOCAL VARIABLES:
      character(len=16) :: inst_suffix
-!EOP
+     character(len=17) :: timestamp
+     logical :: exists
+     !EOP
 !-----------------------------------------------------------------------
 
      call get_inst_suffix(inst_suffix)
-
+     write(timestamp,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') '.',yr,'-',mon,'-',day,'-',tod
      ! NOTE(wjs, 2021-09-20) In other places, we put the ice sheet name *after* the instance
      ! number. However, I feel like there may be some code that assumes that, for rpointer
      ! files, the instance number comes last. In case my recollection is right about that
      ! (or in case anyone introduces code with that assumption), I am putting the instance
      ! number at the end of the rpointer file name.
-     rpointer_filename = 'rpointer.glc.'//trim(icesheet_name)//trim(inst_suffix)
-
+     rpointer_filename = 'rpointer.glc.'//trim(icesheet_name)//trim(inst_suffix)//timestamp
+     if(toread) then
+        inquire(file=trim(rpointer_filename), exist=exists)
+        if(.not. exists) then
+           rpointer_filename = 'rpointer.glc.'//trim(icesheet_name)//trim(inst_suffix)
+        endif
+     endif
+     
    end function get_rpointer_filename
 
 end module glc_files

--- a/source_glc/glc_io.F90
+++ b/source_glc/glc_io.F90
@@ -90,7 +90,7 @@
        modelymd = yr*10000+mon*100+day
        ! get restart filename from rpointer file
        ptr_unit = shr_file_getUnit()
-       open(ptr_unit,file=get_rpointer_filename(icesheet_name, yr, mon, day, tod))
+       open(ptr_unit,file=get_rpointer_filename(icesheet_name, yr, mon, day, tod, .true.))
        read(ptr_unit,'(a)') filename0
        filename = trim(filename0)
        close(ptr_unit)
@@ -509,7 +509,7 @@
     ! write pointer to restart file
     if (my_task == master_task) then
        ptr_unit = shr_file_getUnit()
-       open(ptr_unit,file=get_rpointer_filename(icesheet_name, cesmYR, cesmMON, cesmDAY, cesmTOD))
+       open(ptr_unit,file=get_rpointer_filename(icesheet_name, cesmYR, cesmMON, cesmDAY, cesmTOD, .false.))
        write(ptr_unit,'(a)') filename
        close(ptr_unit)
        call shr_file_freeunit(ptr_unit)


### PR DESCRIPTION
Bringing in @jedwards4b updates for rpointer filenames. This is a replacement for PR #108 

From that PR:
Add timestamps to the rpointer files - we would like this in cesm3_0_beta04.
I've tested the cesm3 beta test suite, in particular:
ERI_Ly15.f09_g17_gris4.T1850Gg.derecho_intel.cism-isostasy_period4
Thanks,