### PR TITLE
reverse stop and restart alarm initialize order

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,18 @@ This file describes what tags were created on master and why
 ================================================================================
 
 Originator: jedwards & katetc
+Date: Oct 29, 2024
+Version: cismwrap_2_2_005
+One-line summary: Reverse initialization of stop and restart alarms
+
+Purpose of changes:
+	Allows the stop alarm to be used in the initialization of the restart
+	alarm by initializing the stop alarm first.
+
+
+
+
+Originator: jedwards & katetc
 Date: Oct 9, 2024
 Version: cismwrap_2_2_004
 One-line summary: Add timestamps to rpointer file names

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,8 +11,37 @@ Purpose of changes:
 	Allows the stop alarm to be used in the initialization of the restart
 	alarm by initializing the stop alarm first.
 
+Standalone checkout supported in this tag (Yes/No): Yes
+   (If yes, this implies that we expect to be able to build and run a
+   case from a standalone checkout using git-fleximod, and for this
+   to continue to work long-term. The answer may be "No" if the set of
+   externals pointed to by manage_externals is broken, or if at least
+   one external points to a temporary branch that is may be deleted in
+   the near future.)
 
+If No: Notes on externals used for testing:
 
+Changes answers relative to previous tag: No - b4b
+
+Bugs fixed (include github issue number):
+
+	No documented issues addressed here.
+
+Summary of testing:
+
+	aux_glc test suite on Derecho for both Intel and Gnu run. Baseline
+	compared to cismwrap_2_2_004, all tests pass B4B except expected
+	failure. Generated new baselines.
+
+	aux_glc/derecho/intel:
+	- All pass
+
+	aux_glc/derecho/gnu:
+	- All pass except:
+
+	NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: FAIL) details:
+	FAIL NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu COMPARE_base_multiinst
+	** Expected failure ** See https://github.com/ESCOMP/CISM-wrapper/issues/110
 
 Originator: jedwards & katetc
 Date: Oct 9, 2024

--- a/drivers/cpl/nuopc/glc_comp_nuopc.F90
+++ b/drivers/cpl/nuopc/glc_comp_nuopc.F90
@@ -746,28 +746,6 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        !----------------
-       ! Restart alarm
-       !----------------
-       call ESMF_LogWrite(subname//'setting restart alarm for cism' , ESMF_LOGMSG_INFO)
-       call NUOPC_CompAttributeGet(gcomp, name="restart_option", value=restart_option, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call NUOPC_CompAttributeGet(gcomp, name="restart_n", value=cvalue, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) restart_n
-
-       call NUOPC_CompAttributeGet(gcomp, name="restart_ymd", value=cvalue, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-       read(cvalue,*) restart_ymd
-
-       call alarmInit(mclock, alarm, restart_option, opt_n=restart_n,  opt_ymd=restart_ymd, &
-            RefTime=mcurrTime, alarmname='alarm_restart', rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       call ESMF_AlarmSet(alarm, clock=mclock, rc=rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-
-       !----------------
        ! Stop alarm
        !----------------
        call ESMF_LogWrite(subname//'setting stop alarm for cism' , ESMF_LOGMSG_INFO)
@@ -784,6 +762,28 @@ contains
 
        call alarmInit(mclock, alarm, stop_option, opt_n=stop_n, opt_ymd=stop_ymd, &
             RefTime = mcurrTime, alarmname = 'alarm_stop', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call ESMF_AlarmSet(alarm, clock=mclock, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       !----------------
+       ! Restart alarm
+       !----------------
+       call ESMF_LogWrite(subname//'setting restart alarm for cism' , ESMF_LOGMSG_INFO)
+       call NUOPC_CompAttributeGet(gcomp, name="restart_option", value=restart_option, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+
+       call NUOPC_CompAttributeGet(gcomp, name="restart_n", value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) restart_n
+
+       call NUOPC_CompAttributeGet(gcomp, name="restart_ymd", value=cvalue, rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+       read(cvalue,*) restart_ymd
+
+       call alarmInit(mclock, alarm, restart_option, opt_n=restart_n,  opt_ymd=restart_ymd, &
+            RefTime=mcurrTime, alarmname='alarm_restart', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
        call ESMF_AlarmSet(alarm, clock=mclock, rc=rc)


### PR DESCRIPTION
In order to set a restart alarm triggered at the end of the run it is necessary to
reverse the order of stop and restart alarm initialization.