### PR TITLE
Point to new location of xglc and remove pointers to mct components

### DIFF
--- a/.config_files.xml
+++ b/.config_files.xml
@@ -17,12 +17,10 @@
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value component="cism"                        >$SRCROOT</value>
-      <value component="dglc"                        >$SRCROOT/components/cdeps/dglc</value>
-      <value component="sglc" comp_interface="mct"   >$SRCROOT/components/cpl7/components/stub_comps_$COMP_INTERFACE/sglc</value>
-      <value component="sglc" comp_interface="nuopc" >$CIMEROOT/CIME/non_py/src/components/stub_comps_$COMP_INTERFACE/sglc</value>
-      <value component="xglc" comp_interface="mct"   >$SRCROOT/components/cpl7/components/xcpl_comps_$COMP_INTERFACE/xglc</value>
-      <value component="xglc" comp_interface="nuopc" >$CIMEROOT/CIME/non_py/src/components/xcpl_comps_$COMP_INTERFACE/xglc</value>
+      <value component="cism">$SRCROOT</value>
+      <value component="dglc">$SRCROOT/components/cdeps/dglc</value>
+      <value component="sglc">$CIMEROOT/CIME/non_py/src/components/stub_comps_$COMP_INTERFACE/sglc</value>
+      <value component="xglc">$SRCROOT/components/cmeps/med_test_comps/xglc</value>
     </values>
     <group>case_comps</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
(1) Point to new location of xglc. This change is tied to https://github.com/ESCOMP/CMEPS/pull/637 and
https://github.com/ESMCI/cime/pull/4946 (but this PR can be merged before or after those because it's unusual to run X compset tests from a standalone CTSM checkout).

(2) Remove references to no-longer-existent mct components