### PR TITLE
Katetc/reprosum testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "source_cism"]
 path = source_cism
 url = https://github.com/ESCOMP/cism
-fxtag = cism_main_2.02.003
+fxtag = lipscomb/reproducible_sums
 fxrequired = AlwaysRequired
 fxDONOTUSEurl = https://github.com/ESCOMP/cism
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "source_cism"]
 path = source_cism
 url = https://github.com/ESCOMP/cism
-fxtag = lipscomb/reproducible_sums
+fxtag = cism_main_2.02.004
 fxrequired = AlwaysRequired
 fxDONOTUSEurl = https://github.com/ESCOMP/cism
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,83 @@ This file describes what tags were created on master and why
 
 Originator: katetc
 Date: April 07, 2026
+Version: cismwrap_2_2_015
+One-line summary: Add support for reproducible sums with changing processor counts.
+
+Purpose of changes:
+	Updated to a new CISM tag that now includes the namelist parameter reproducible_sums that,
+	when true, allows for a b4b restart after changing PE layout. This parameter is set to
+	true by default in CESM. This PR also includes two new ERP tests to verify this functionality,
+	and one test mod directory ("norenormal") which turns off the coupler renormalization step
+	that is NOT b4b with changing PEs. This is required to pass an ERP test with a T compset
+	for now. Discussed in issue https://github.com/ESCOMP/CMEPS/issues/650
+
+Standalone checkout supported in this tag (Yes/No): Yes
+   (If yes, this implies that we expect to be able to build and run a
+   case from a standalone checkout using git-fleximod, and for this
+   to continue to work long-term. The answer may be "No" if the set of
+   externals pointed to by manage_externals is broken, or if at least
+   one external points to a temporary branch that is may be deleted in
+   the near future.)
+
+If No: Notes on externals used for testing:
+
+Changes answers relative to previous tag: Yes
+
+Bugs fixed (include github issue number):
+	- Addresses https://github.com/ESCOMP/CISM-wrapper/issues/132
+	- Addresses https://github.com/Katetc/work_planning_repo/issues/36
+	- Addresses https://github.com/ESCOMP/CTSM/issues/2542
+	- Accidentally seems to have fixed https://github.com/ESCOMP/CISM-wrapper/issues/140
+
+Summary of testing:
+        aux_glc test suite on Derecho for both Intel and Gnu run. Baseline compared to cismwrap_2_2_014.
+	All tests DIFF with answer changes EXCEPT those without active CISM running.
+
+	ERI_Ly10.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-isostasy_period4 (Overall: DIFF) details:
+	ERI_Ly15.f09_g17_gris4.T1850Gg.derecho_intel.cism-isostasy_period4 (Overall: DIFF) details:
+	ERI_Ly44.f09_g17_gris20.T1850Gg.derecho_intel.cism-isostasy_period4 (Overall: DIFF) details:
+	ERP_Ly4.f09_g17_gris4.T1850Gg.derecho_intel.cism-norenormal (Overall: DIFF) details:
+	ERS_D_Ly3.f09_g17_ais8gris4.T1850Gag.derecho_intel (Overall: DIFF) details:
+	ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-cmip6_evolving_icesheet (Overall: DIFF) details:
+	ERS_Ly3_C2_D.f09_g17_gris20.T1850Gg.derecho_intel (Overall: DIFF) details:
+	ERS_Ly3.f10_f10_ais8_mg37.I1850Clm50SpGa.derecho_intel (Overall: DIFF) details:
+	ERS_Ly3.f10_f10_mg37.I1850Clm50SpG.derecho_intel (Overall: DIFF) details:
+	ERS_Ly4.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_intel (Overall: DIFF) details:
+	ERS_Ly5.f09_g17_ais8.T1850Ga.derecho_intel (Overall: DIFF) details:
+	ERS_Ly7.f09_g17_gris4.T1850Gg.derecho_intel (Overall: DIFF) details:
+	MULTINOAIS_Ly2.f10_f10_ais8gris4_mg37.I1850Clm50SpRsGag.derecho_intel.cism-change_params (Overall: DIFF) details:
+	MULTINOGRIS_Ly2.f10_f10_ais8gris4_mg37.I1850Clm50SpRsGag.derecho_intel.cism-change_params (Overall: DIFF) details:
+	SMS_D_Ly1.f09_g17_ais8.T1850Ga.derecho_intel (Overall: DIFF) details:
+	SMS_D_Ly1.f09_g17_gris4.T1850Gg.derecho_intel.cism-isostasy_period1 (Overall: DIFF) details:
+	SMS_D_Ly1.f09_g17_gris4.T1850Gg.derecho_intel (Overall: DIFF) details:
+
+	No active CISM:
+	ERS_D_Ly3.f09_g17_gris4.T1850Gg.derecho_intel.cism-noevolve (Overall: NLFAIL) details:
+	SMS_D_Ld5.f10_f10_ais8gris4_mg37.JK1850D.derecho_intel (Overall: PASS) details:
+	SMS_Lm13.f10_f10_mg37.I1850Clm50SpG.derecho_intel.cism-noevolve (Overall: NLFAIL) details:
+
+	ERI_C2_Ly9.f09_g17_ais8gris4.T1850Gag.derecho_gnu (Overall: DIFF) details:
+	ERI.f10_f10_mg37.I1850Clm50SpG.derecho_gnu.cism-test_coupling (Overall: DIFF) details:
+	ERI_Ly9.f09_g17_ais8gris4.T1850Gag.derecho_gnu.cism-noevolve_ais (Overall: DIFF) details:
+	ERP_Ly5.f09_g17_ais8.T1850Ga.derecho_gnu.cism-norenormal (Overall: DIFF) details:
+	ERS_D_Ld9.f10_f10_mg37.I1850Clm50SpG.derecho_gnu.cism-override_glc_frac (Overall: DIFF) details:
+	ERS_Ly11.f09_g17_gris20.T1850Gg.derecho_gnu.cism-oneway (Overall: DIFF) details:
+	ERS_Ly11.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: DIFF) details:
+	ERS_Ly3.f09_g17_gris4.T1850Gg.derecho_gnu.cism-isostasy_period1 (Overall: DIFF) details:
+	ERS_Ly5.f09_g17_gris4.T1850Gg.derecho_gnu.cism-isostasy_period4 (Overall: DIFF) details:
+	MCC_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: DIFF) details:
+	SMS_D_Ld5.f10_f10_ais8gris4_mg37.I1850Clm50SpGag.derecho_gnu.cism-test_coupling (Overall: DIFF) details:
+	SMS_D_Ly1.f09_g17_ais8.T1850Ga.derecho_gnu (Overall: DIFF) details:
+	SMS_D_Ly1.f09_g17_gris4.T1850Gg.derecho_gnu (Overall: DIFF) details:
+
+	NCK_Ly3.f09_g17_gris20.T1850Gg.derecho_gnu (Overall: FAIL) details:
+	** Expected failure ** See https://github.com/ESCOMP/CISM-wrapper/issues/110
+
+================================================================================
+
+Originator: katetc
+Date: April 07, 2026
 Version: cismwrap_2_2_014
 One-line summary: Update externals to cesm3_0_beta08
 

--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -2206,7 +2206,7 @@ Sub-elements of each entry include:
       <value>0.0</value>
     </values>
     <desc>
-      Min value of thermal_forcing_basin (deg C) applied to nonlocal and 
+      Min value of thermal_forcing_basin (deg C) applied to nonlocal and
       nonlocal-slope schemes
       Default: 0.0
     </desc>
@@ -2934,6 +2934,20 @@ Sub-elements of each entry include:
     <desc>
       Flag that indicates whether peripheral ice caps are removed and added to an ice loss flux
       Default: true
+    </desc>
+  </entry>
+
+    <entry id="reproducible_sums">
+    <type>logical</type>
+    <category>cism_config_ho_options</category>
+    <group>ho_options</group>
+    <values>
+      <value>.true.</value>
+    </values>
+    <desc>
+      Flag that changes the solver to use code to produce b4b the same solution regardless of
+      the number of cores or PE layout.
+      Default: true (only for CESM, false in standalone)
     </desc>
   </entry>
 

--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -2146,7 +2146,7 @@ Sub-elements of each entry include:
     </desc>
   </entry>
 
-  <entry id="babc_length_scale">
+  <entry id="inversion_babc_length_scale">
     <type>real</type>
     <category>cism_config_parameters</category>
     <group>parameters</group>
@@ -2159,7 +2159,7 @@ Sub-elements of each entry include:
     </desc>
   </entry>
 
-  <entry id="deltaT_ocn_length_scale">
+  <entry id="inversion_deltaT_ocn_length_scale">
     <type>real</type>
     <category>cism_config_parameters</category>
     <group>parameters</group>
@@ -2732,7 +2732,7 @@ Sub-elements of each entry include:
     <valid_values>0,1,2,3,4</valid_values>
     <values>
       <value icesheet="gris">1</value>
-      <value icesheet="ais" >3</value>
+      <value icesheet="ais" >1</value>
     </values>
     <desc>
       Flag that indicates which Stokes preconditioner to use in the Glissade dycore.
@@ -2742,7 +2742,7 @@ Sub-elements of each entry include:
       2: Physics-based shallow-ice preconditioner
       3: Local tridiagonal preconditioner (one solve per task)
       4: Global tridiagonal preconditioner (global solve)
-      Default: 1 for Greenland, 3 for Antarctica
+      Default: 1 for Greenland, 1 for Antarctica
     </desc>
   </entry>
 
@@ -2870,7 +2870,7 @@ Sub-elements of each entry include:
     <group>ho_options</group>
     <valid_values>0,1,2,3</valid_values>
     <values>
-      <value>3</value>
+      <value>2</value>
     </values>
     <desc>
       Flag that indicates how to compute the flotation function at and near vertices in the Glissade dycore
@@ -2916,11 +2916,12 @@ Sub-elements of each entry include:
     <category>cism_config_ho_options</category>
     <group>ho_options</group>
     <values>
-      <value>.true.</value>
+      <value icesheet="gris">.true.</value>
+      <value icesheet="ais" >.false</value>
     </values>
     <desc>
       Flag that indicates whether ice inception away from the main ice sheet is blocked
-      Default: true
+      Default: true for gris, false for ais
     </desc>
   </entry>
 
@@ -2930,10 +2931,11 @@ Sub-elements of each entry include:
     <group>ho_options</group>
     <values>
       <value>.true.</value>
+      <value icesheet="ais" >.false.</value>
     </values>
     <desc>
       Flag that indicates whether peripheral ice caps are removed and added to an ice loss flux
-      Default: true
+      Default for gris = true, for ais = false
     </desc>
   </entry>
 

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -71,20 +71,6 @@
     </machines>
   </test>
 
-  <!-- Remove mct tests as they are no longer supported -->
-  <!--test name="ERS_Vmct_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
-    <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">ice evolution off is the typical operation of cism within cesm, so test that configuration</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test-->
-
   <!-- BUG(wjs, 2021-09-29, ESCOMP/CISM-wrapper#60) This currently fails
        at namelist generation time, with "ERROR: for TG compset require
        that lnd_cpl_time equal glc_cpl_time". If I remember correctly,
@@ -291,6 +277,35 @@
     </machines>
   </test>
 
+<test name="ERP_Ly4" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/norenormal">
+    <machines>
+      <machine name="derecho" compiler="intel" category="aux_glc">
+        <options>
+          <option name="wallclock">0:20:00</option>
+          <!-- Adding ERP tests to check for exact restarts with changing processors. As of 05/2026, there
+	       are global sums in cmeps that prevent this from passing. This is why we turn off renormalization
+	  -->
+          <option name="comment">Test for exact b4b restart with changing processor counts</option>
+        </options>
+      </machine>
+    </machines>
+</test>
+
+<test name="ERP_Ly5" grid="f09_g17_ais8" compset="T1850Ga" testmods="cism/norenormal">
+    <machines>
+      <machine name="derecho" compiler="gnu" category="aux_glc">
+        <options>
+          <option name="wallclock">0:20:00</option>
+          <!-- Adding ERP tests to check for exact restarts with changing processors. As of 05/2026, there
+	       are global sums in cmeps that prevent this from passing. This is why we turn off renormalization
+	  -->
+          <option name="comment">Test for exact b4b restart with changing processor counts</option>
+        </options>
+      </machine>
+    </machines>
+  </test>
+
+  
   <test name="NCK_Ly3" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
 

--- a/cime_config/testdefs/testmods_dirs/cism/norenormal/user_nl_cpl
+++ b/cime_config/testdefs/testmods_dirs/cism/norenormal/user_nl_cpl
@@ -1,0 +1,21 @@
+!------------------------------------------------------------------------
+! Users should ONLY USE user_nl_cpl to change namelists variables
+! for namelist variables in drv_in (except for the ones below) and
+! any keyword/values in seq_maps.rc
+! Users should add ALL user specific namelist and seq_maps.rc changes below
+! using the following syntax
+!   namelist_var = new_namelist_value
+! or
+!   mapname = new_map_name
+! For example to change the default value of ocn2atm_fmapname to 'foo' use
+!   ocn2atm_fmapname =  'foo'
+!
+! Note that some namelist variables MAY NOT be changed in user_nl_cpl - 
+! they are defined in a $CASEROOT xml file and must be changed with
+! xmlchange.
+!
+! For example, rather than set username to 'foo' in user_nl_cpl, call
+! ./xmlchange USER=foo
+!------------------------------------------------------------------------
+
+glc_renormalize_smb = 'off'


### PR DESCRIPTION
Add support for new CISM external that can now restart b4b after changing processor counts (pass an ERP CIME test). Includes a new namelist parameter **reproducible_sums** which is true by default in CESM. Also new ERP tests for both the gnu and intel compiler. And just a few other namelist updates.

Addresses https://github.com/ESCOMP/CISM-wrapper/issues/132
Addresses https://github.com/Katetc/work_planning_repo/issues/36
Addresses https://github.com/ESCOMP/CTSM/issues/2542
Accidentally seems to have fixed https://github.com/ESCOMP/CISM-wrapper/issues/140